### PR TITLE
Accept Angular version 1.2 onwards

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,10 +22,10 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.2"
+    "angular": ">=1.2"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2",
+    "angular-mocks": ">=1.2",
     "jquery": "~2.1"
   }
 }


### PR DESCRIPTION
Allow using the module with more recent Angular versions. Successfully tested with Angular 1.4.5
